### PR TITLE
Typo in 7.16.2

### DIFF
--- a/_sources/Iteration/kiva_statistics.rst
+++ b/_sources/Iteration/kiva_statistics.rst
@@ -292,7 +292,7 @@ Historically the pearson correlation coefficient has been used in recommender sy
 .. activecode:: act_kiva_12
     :include: act_kiva_1
 
-    Calculate the pearson correlation between the loan_amount and the num_lenders_total or between time_to_raise and the loan_amout or between num_lenders_total and time_to_raise.  If you divide up the class you can compare values to see which pair has the strongest correlation.
+    Calculate the pearson correlation between the loan_amount and the num_lenders_total or between time_to_raise and the loan_amount or between num_lenders_total and time_to_raise.  If you divide up the class you can compare values to see which pair has the strongest correlation.
     ~~~~
     loan_amount_num_lenders = 0
     loan_amount_ttr = 0


### PR DESCRIPTION
Fixed directions in calculating the pearson correlation: loan_amout should be loan_amount.